### PR TITLE
Statistics1

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -5,6 +5,12 @@ function notifyComplete() {
   window.postMessage({ type: "COMPLETE" }, "*");
 }
 
+function notifyDeath() {
+
+}
+
+var deathCount = 0;
+
 Bn.prototype.oldDC = Bn.prototype.DC;
 Bn.prototype.DC = function() {
   if (C.BU && C.Be == C.BU) {
@@ -36,3 +42,16 @@ if (window.location.search == "?finish") {
 if (C.BU == 0){
   notifyComplete();
 }
+window.onkeyup = function(e) {
+    var key = e.keyCode ? e.keyCode : e.which;
+
+    if (key == 13 || key == 8) { 
+    // increment death count on backspace or enter (return to previous checkpoint and respawn)
+    deathCount++;
+
+    var span = document.getElementsByClassName("statistic_value")[0];
+    span.innerHTML = "" + deathCount;
+  }
+}
+var span = document.getElementsByClassName("statistic_value")[0];
+span.innerHTML = "" + deathCount;

--- a/page.css
+++ b/page.css
@@ -21,3 +21,36 @@
 .status_completed {
   background-color: #0F0;
 }
+
+.statistics {
+  width: 80px;
+  height: 20px;
+  position: absolute;
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-border-radius: 10px;
+  text-align: left;
+  top: 50px;
+  left: 30px;
+  z-index: 9002;
+  line-height: 2.6em;
+  background-color: #4C4C4C;
+}
+
+.statistic_key {
+  margin-right: 10px;
+  color: #FDFDFD;
+  text-shadow:
+  -1px -1px 0 #000,
+  1px -1px 0 #000,
+  -1px 1px 0 #000,
+  1px 1px 0 #000; 
+}
+.statistic_value {
+  color: #FDFDFD;
+  text-shadow:
+  -1px -1px 0 #000,
+  1px -1px 0 #000,
+  -1px 1px 0 #000,
+  1px 1px 0 #000; 
+}

--- a/page.js
+++ b/page.js
@@ -15,10 +15,23 @@ var span = document.createElement("span");
 span.className = "status";
 document.body.appendChild(span);
 
+var statisticsSpan = document.createElement("span");
+statisticsSpan.className = "statistics";
+document.body.appendChild(statisticsSpan);
+
+var deathsSpan = document.createElement("span");
+$(deathsSpan).addClass("statistic_key").text("deaths:");
+
+var deathsSpanValue = document.createElement("span");
+$(deathsSpanValue).addClass("statistic_value").text("");
+
+statisticsSpan.appendChild(deathsSpan);
+statisticsSpan.appendChild(deathsSpanValue);
+
 var href = $("span.green").next().attr("href");
 track = parseInt(href.split("/")[1]);
 
-chrome.runtime.sendMessage({"get":track},function(res){
+chrome.runtime.sendMessage({"get":track},function(res) {
   if (res == 0) {
     $(span).addClass("status_new").text("NEW");
   } else if (res == 1) {
@@ -26,6 +39,16 @@ chrome.runtime.sendMessage({"get":track},function(res){
   } else {
     $(span).addClass("status_completed").text("COMPLETED");
   }
+  $(span).click(function(){
+    if (statisticsSpan.style.visibility == 'hidden') {
+      statisticsSpan.style.visibility = 'visible';   
+    }
+    else {
+      statisticsSpan.style.visibility = 'hidden';
+    }
+  });
+
+  statisticsSpan.style.visibility = 'visible';
 });
 
 $(document).ready(function(){


### PR DESCRIPTION
The extension needs more statistics

Added a statistics window underneath the status indicator. The statistics visibility can be toggled by clicking the status indicator. 

For now, I  just added a death count. 

Eventually, I'm thinking we should have a set of "this time run stats" such as deaths, etc, and a set of "all time run stats" like fastest completion, fewest deaths, etc. If that sounds good let me know and I'll go forward with that. This would include modifying the way track data is stored.
